### PR TITLE
Keep app bar in a fixed position when scrolling

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')
+    implementation project(':capacitor-status-bar')
     implementation project(':send-intent')
 
 }

--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -16,6 +16,9 @@
 		},
 		"CapacitorHttp": {
 			"enabled": true
+		},
+		"StatusBar": {
+			"overlaysWebView": true
 		}
 	},
 	"cordova": {}

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -36,6 +36,10 @@
 		"classpath": "com.capacitorjs.plugins.splashscreen.SplashScreenPlugin"
 	},
 	{
+		"pkg": "@capacitor/status-bar",
+		"classpath": "com.capacitorjs.plugins.statusbar.StatusBarPlugin"
+	},
+	{
 		"pkg": "send-intent",
 		"classpath": "de.mindlib.sendIntent.SendIntent"
 	}

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -29,5 +29,8 @@ project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/sh
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 
+include ':capacitor-status-bar'
+project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
 include ':send-intent'
 project(':send-intent').projectDir = new File('../node_modules/send-intent/android')

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -16,6 +16,9 @@
     },
     "CapacitorHttp": {
       "enabled": true
+    },
+    "StatusBar": {
+      "overlaysWebView": true
     }
   },
   "cordova": {}

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -16,6 +16,9 @@
 		},
 		"CapacitorHttp": {
 			"enabled": true
+		},
+		"StatusBar": {
+			"overlaysWebView": true
 		}
 	},
 	"cordova": {},
@@ -29,6 +32,7 @@
 		"PreferencesPlugin",
 		"SharePlugin",
 		"SplashScreenPlugin",
+		"StatusBarPlugin",
 		"SendIntentPlugin"
 	]
 }

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -20,6 +20,7 @@ def capacitor_pods
   pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
   pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
+  pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
   pod 'SendIntent', :path => '../../node_modules/send-intent'
 end
 

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -2,27 +2,29 @@ PODS:
   - ByteowlsCapacitorOauth2 (5.0.0):
     - Capacitor
     - OAuthSwift (= 2.2.0)
-  - Capacitor (6.1.1):
+  - Capacitor (7.1.0):
     - CapacitorCordova
-  - CapacitorApp (6.0.0):
+  - CapacitorApp (7.0.0):
     - Capacitor
-  - CapacitorBrowser (6.0.1):
+  - CapacitorBrowser (7.0.0):
     - Capacitor
-  - CapacitorCordova (6.1.1)
-  - CapacitorDevice (6.0.0):
+  - CapacitorCordova (7.1.0)
+  - CapacitorDevice (7.0.0):
     - Capacitor
-  - CapacitorFilesystem (6.0.0):
+  - CapacitorFilesystem (7.0.0):
     - Capacitor
-  - CapacitorNetwork (6.0.1):
+  - CapacitorNetwork (7.0.0):
     - Capacitor
-  - CapacitorPreferences (6.0.1):
+  - CapacitorPreferences (7.0.0):
     - Capacitor
-  - CapacitorShare (6.0.1):
+  - CapacitorShare (7.0.0):
     - Capacitor
-  - CapacitorSplashScreen (6.0.1):
+  - CapacitorSplashScreen (7.0.0):
+    - Capacitor
+  - CapacitorStatusBar (7.0.1):
     - Capacitor
   - OAuthSwift (2.2.0)
-  - SendIntent (0.0.1):
+  - SendIntent (7.0.0):
     - Capacitor
 
 DEPENDENCIES:
@@ -37,6 +39,7 @@ DEPENDENCIES:
   - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
   - "CapacitorShare (from `../../node_modules/@capacitor/share`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
+  - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
   - SendIntent (from `../../node_modules/send-intent`)
 
 SPEC REPOS:
@@ -66,24 +69,27 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/share"
   CapacitorSplashScreen:
     :path: "../../node_modules/@capacitor/splash-screen"
+  CapacitorStatusBar:
+    :path: "../../node_modules/@capacitor/status-bar"
   SendIntent:
     :path: "../../node_modules/send-intent"
 
 SPEC CHECKSUMS:
   ByteowlsCapacitorOauth2: 9e7cdae2bf251463a6ad89493e27fb288bf694d7
-  Capacitor: 8941aba4364ba9d1b22188569001f2ce45cc2b00
-  CapacitorApp: 9d53aec7101f7b030a950c5bdc4df8612576b279
-  CapacitorBrowser: 473c7fd70ddbe541608ff09ec1be14da0078279e
-  CapacitorCordova: 8f2cc8d8d3619c566e9418fe8772064a94266106
-  CapacitorDevice: f8fd88f9edd1261c55a109f32015b09bbbfdc4a0
-  CapacitorFilesystem: 60e59ba274c234a979e7a3be2552feaadcee4263
-  CapacitorNetwork: 5c94acfdddc22043f2ffaff224ce9b4aa5a179f0
-  CapacitorPreferences: 72909b165bc7807103778ddbb86d5d8ce06abf71
-  CapacitorShare: 02222f2457ff003e642370a9c1ecd101baaa27c8
-  CapacitorSplashScreen: 61645214e8f955ff2b80f16a6a3648960fe4c89f
+  Capacitor: 68ff8eabbcce387e69767c13b5fbcc1c5399eabc
+  CapacitorApp: 45cb7cbef4aa380b9236fd6980033eb5cde6fcd2
+  CapacitorBrowser: 352a66541b15ceadae1d703802b11979023705e3
+  CapacitorCordova: 866217f32c1d25b326c568a10ea3ed0c36b13e29
+  CapacitorDevice: 62066b65e148a133df7b8c5bf972ba835b329748
+  CapacitorFilesystem: 2881ad012b5c8d0ffbfed1216aadfc2cca16d5b5
+  CapacitorNetwork: cd17b98182841055ff58629213242a1f22f4a76b
+  CapacitorPreferences: e24a50a936f0e4f54a6b43be6121f923b4d91c27
+  CapacitorShare: 2fcf1758cd07e0558f6aed40d7437bf8a3a42297
+  CapacitorSplashScreen: f4e58cc02aafd91c7cbaf32a3d1b44d02a115125
+  CapacitorStatusBar: 275cbf2f4dfc00388f519ef80c7ec22edda342c9
   OAuthSwift: 75efbb5bd9a4b2b71a37bd7e986bf3f55ddd54c6
-  SendIntent: 0a17b6984c4f27e9dfa56513267ba2c044a5a6c8
+  SendIntent: 1f4f65c7103eb423067c566682dfcda973b5fb29
 
-PODFILE CHECKSUM: ec4a5e49843d3546e8e3d2415a3cc07be4758a27
+PODFILE CHECKSUM: 5f190d3cd506bedc6bc77c16b4323e26407cdc66
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floccus",
-  "version": "5.5.4",
+  "version": "5.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floccus",
-      "version": "5.5.4",
+      "version": "5.5.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@byteowls/capacitor-oauth2": "5.x",
@@ -21,6 +21,7 @@
         "@capacitor/preferences": "7.x",
         "@capacitor/share": "7.x",
         "@capacitor/splash-screen": "7.x",
+        "@capacitor/status-bar": "7.x",
         "@isomorphic-git/lightning-fs": "^4.6.0",
         "@sentry/vue": "7.x",
         "@sentry/webpack-plugin": "2.x",
@@ -1846,6 +1847,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-7.0.0.tgz",
       "integrity": "sha512-y25WNRcl+MY/ltb3OZPZPpNmhVFW9270QneJY8tjY7FJc78zWEszj1cX84LJS4LeTHfHi4NcNW4y0/oewWG88A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.1.tgz",
+      "integrity": "sha512-iDv3mXYo9CdxYRVwt3/pRyuk25p7Sn4GfaS/zMZyVIqTzsvKLCIIH3GdKK+ta+nsNcAVpCw/t5jFEBt1D18ctA==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@capacitor/preferences": "7.x",
     "@capacitor/share": "7.x",
     "@capacitor/splash-screen": "7.x",
+    "@capacitor/status-bar": "7.x",
     "@isomorphic-git/lightning-fs": "^4.6.0",
     "@sentry/vue": "7.x",
     "@sentry/webpack-plugin": "2.x",

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -17,7 +17,7 @@
         </v-btn>
       </template>
     </v-banner>
-    <v-content>
+    <v-content style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
       <router-view />
     </v-content>
     <v-footer

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -17,7 +17,7 @@
         </v-btn>
       </template>
     </v-banner>
-    <v-content style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
+    <v-content>
       <router-view />
     </v-content>
     <v-footer

--- a/src/ui/NativeApp.vue
+++ b/src/ui/NativeApp.vue
@@ -65,20 +65,17 @@ html {
 }
 
 .native-scroll-container {
-  background: red;
   position: absolute;
   inset: 0;
   overflow: hidden;
 
   .v-app-bar {
     top: env(safe-area-inset-top) !important;
-    background: green;
   }
 
   .v-main {
     height: 100%;
     overflow-y: auto;
-    background: yellow;
   }
 }
 </style>

--- a/src/ui/NativeApp.vue
+++ b/src/ui/NativeApp.vue
@@ -41,9 +41,6 @@ export default {
 </script>
 <style>
 body {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
@@ -58,9 +55,30 @@ body {
 }
 html {
   font-size: 0.45cm !important;
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
 }
 .v-navigation-drawer {
   top: env(safe-area-inset-top) !important;
   bottom: 0;
+}
+
+.native-scroll-container {
+  background: red;
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+
+  .v-app-bar {
+    top: env(safe-area-inset-top);
+    background: green;
+  }
+
+  .v-main {
+    height: 100%;
+    overflow-y: auto;
+    background: yellow;
+  }
 }
 </style>

--- a/src/ui/NativeApp.vue
+++ b/src/ui/NativeApp.vue
@@ -41,6 +41,9 @@ export default {
 </script>
 <style>
 body {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);

--- a/src/ui/NativeApp.vue
+++ b/src/ui/NativeApp.vue
@@ -71,7 +71,7 @@ html {
   overflow: hidden;
 
   .v-app-bar {
-    top: env(safe-area-inset-top);
+    top: env(safe-area-inset-top) !important;
     background: green;
   }
 

--- a/src/ui/NativeRouter.js
+++ b/src/ui/NativeRouter.js
@@ -2,7 +2,6 @@ import Vue from 'vue'
 import Router from 'vue-router'
 import Tree from './views/native/Tree'
 import Home from './views/native/Home'
-import NewAccount from './views/NewAccount'
 import AddBookmarkIntent from './views/native/AddBookmarkIntent'
 import ImportExport from './views/native/ImportExport'
 import About from './views/native/About'
@@ -44,7 +43,7 @@ export const router = new Router({
     {
       path: '/new',
       name: routes.NEW_ACCOUNT,
-      component: NewAccount,
+      component: () => import(/* webpackPrefetch: true */ './views/native/NewAccount')
     },
     {
       path: '/update',

--- a/src/ui/views/ImportExport.vue
+++ b/src/ui/views/ImportExport.vue
@@ -37,7 +37,7 @@
       </v-container>
     </v-card>
     <v-card
-      class="options mt-3">
+      class="options mt-3 mb-9">
       <v-container class="pa-5">
         <v-card-title>
           {{ t("LabelImport") }}

--- a/src/ui/views/ImportExport.vue
+++ b/src/ui/views/ImportExport.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-card
-      class="options mt-3">
+      class="options">
       <v-container class="pa-5">
         <v-card-title>
           {{ t("LabelExport") }}

--- a/src/ui/views/NewAccount.vue
+++ b/src/ui/views/NewAccount.vue
@@ -1,464 +1,462 @@
 <template>
   <v-container>
-    <v-card class="mt-3 mb-9">
-      <v-stepper v-model="currentStep">
-        <v-stepper-header>
-          <v-stepper-step
-            :complete="currentStep > 0"
-            step="0" />
-          <v-divider />
-          <v-stepper-step
-            :complete="currentStep > 1"
-            step="1" />
-          <v-divider />
-          <v-stepper-step
-            :complete="currentStep > 2"
-            step="2" />
-          <v-divider />
-          <v-stepper-step
-            step="3"
-            :complete="currentStep > 3" />
-          <v-divider />
-          <v-stepper-step
-            step="4"
-            :complete="currentStep > 4" />
-        </v-stepper-header>
+    <v-stepper v-model="currentStep" class="mt-3 mb-9">
+      <v-stepper-header>
+        <v-stepper-step
+          :complete="currentStep > 0"
+          step="0" />
+        <v-divider />
+        <v-stepper-step
+          :complete="currentStep > 1"
+          step="1" />
+        <v-divider />
+        <v-stepper-step
+          :complete="currentStep > 2"
+          step="2" />
+        <v-divider />
+        <v-stepper-step
+          step="3"
+          :complete="currentStep > 3" />
+        <v-divider />
+        <v-stepper-step
+          step="4"
+          :complete="currentStep > 4" />
+      </v-stepper-header>
 
-        <v-stepper-items>
-          <v-stepper-content step="0">
-            <div class="headline">
-              {{ t('LabelChooseadapter') }}
-            </div>
-            <v-form>
-              <v-radio-group v-model="adapter">
-                <div
-                  v-for="a in adapters"
-                  :key="a.type">
-                  <v-radio
-                    :disabled="!isBrowser && a.type === 'git'"
-                    :value="a.type">
-                    <template #label>
-                      <div class="heading">
-                        {{ a.label }}
-                      </div>
-                    </template>
-                  </v-radio>
-                  <div class="caption pl-8 mb-5">
-                    {{ a.description }}
-                  </div>
+      <v-stepper-items>
+        <v-stepper-content step="0">
+          <div class="headline">
+            {{ t('LabelChooseadapter') }}
+          </div>
+          <v-form>
+            <v-radio-group v-model="adapter">
+              <div
+                v-for="a in adapters"
+                :key="a.type">
+                <v-radio
+                  :disabled="!isBrowser && a.type === 'git'"
+                  :value="a.type">
+                  <template #label>
+                    <div class="heading">
+                      {{ a.label }}
+                    </div>
+                  </template>
+                </v-radio>
+                <div class="caption pl-8 mb-5">
+                  {{ a.description }}
                 </div>
-              </v-radio-group>
-            </v-form>
-            <div class="d-flex flex-row-reverse pb-2">
-              <v-btn
-                class="primary"
-                @click="currentStep++">
-                {{ t('LabelContinue') }}
-              </v-btn>
-              <v-btn
-                :to="{ name: 'IMPORTEXPORT' }"
-                class="mr-2">
-                <v-icon>mdi-export</v-icon>
-                <template v-if="isBrowser && true">
-                  {{ t('LabelImportExport') }}
-                </template>
-              </v-btn>
-            </div>
-          </v-stepper-content>
+              </div>
+            </v-radio-group>
+          </v-form>
+          <div class="d-flex flex-row-reverse pb-2">
+            <v-btn
+              class="primary"
+              @click="currentStep++">
+              {{ t('LabelContinue') }}
+            </v-btn>
+            <v-btn
+              :to="{ name: 'IMPORTEXPORT' }"
+              class="mr-2">
+              <v-icon>mdi-export</v-icon>
+              <template v-if="isBrowser && true">
+                {{ t('LabelImportExport') }}
+              </template>
+            </v-btn>
+          </div>
+        </v-stepper-content>
 
-          <v-stepper-content step="1">
-            <div class="headline">
-              {{ t('LabelAccountlabel') }}
-            </div>
-            <v-form>
-              <v-text-field
-                v-model="label"
-                append-icon="mdi-label"
-                class="mt-2 mb-4"
-                :label="t('LabelAccountlabel')"
-                :hint="t('DescriptionAccountlabel')"
-                :persistent-hint="true"
-                @keydown.enter.prevent="currentStep++" />
-            </v-form>
-            <div class="d-flex flex-row justify-space-between pb-2">
-              <v-btn @click="currentStep--">
-                {{ t('LabelBack') }}
-              </v-btn>
-              <v-btn
-                class="primary"
-                @click="currentStep++">
-                {{ t('LabelContinue') }}
-              </v-btn>
-            </div>
-          </v-stepper-content>
-
-          <v-stepper-content step="2">
-            <template v-if="adapter === 'nextcloud-bookmarks'">
-              <div class="headline">
-                {{ t('LabelServersetup') }}
-              </div>
-              <v-text-field
-                v-model="server"
-                :rules="[validateUrl]"
-                :label="t('LabelNextcloudurl')"
-                :loading="isServerTestRunning || isLoginFlowRunning"
-                :error-messages="serverisNotHttps || serverTestError || loginFlowError"
-                @keydown.enter="testNextcloudServer">
-                <template
-                  slot="append-outer">
-                  <v-icon
-                    v-if="serverTestSuccessful"
-                    color="green"
-                    title="Server connection successful">
-                    mdi-check
-                  </v-icon>
-                </template>
-              </v-text-field>
-              <div class="d-flex flex-row justify-space-between pb-2">
-                <v-btn @click="currentStep--">
-                  {{ t('LabelBack') }}
-                </v-btn>
-                <v-btn
-                  v-if="!serverTestSuccessful"
-                  class="primary"
-                  @click="testNextcloudServer">
-                  {{ t('LabelConnect') }}
-                </v-btn>
-                <template v-if="serverTestSuccessful">
-                  <v-btn
-                    v-if="!isLoginFlowRunning"
-                    class="primary"
-                    @click="onFlowStart">
-                    {{ t('LabelLoginFlowStart') }}
-                  </v-btn>
-                  <v-btn
-                    v-if="isLoginFlowRunning"
-                    @click="onFlowStop">
-                    {{ t('LabelLoginFlowStop') }}
-                  </v-btn>
-                </template>
-              </div>
-            </template>
-
-            <template v-else-if="adapter === 'linkwarden'">
-              <div class="headline">
-                {{ t('LabelServersetup') }}
-              </div>
-              <v-text-field
-                v-model="server"
-                :rules="[validateUrl]"
-                :label="t('LabelLinkwardenurl')"
-                :loading="isServerTestRunning"
-                :error-messages="serverTestError || serverisNotHttps" />
-              <v-text-field
-                v-model="username"
-                :label="t('LabelUsername')" />
-              <v-text-field
-                v-model="password"
-                :label="t('LabelAccesstoken')"
-                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-                :type="showPassword ? 'text' : 'password'"
-                @click:append="showPassword = !showPassword" />
-
-              <div class="d-flex flex-row justify-space-between pb-2">
-                <v-btn @click="currentStep--">
-                  {{ t('LabelBack') }}
-                </v-btn>
-                <v-btn
-                  class="primary"
-                  @click="testLinkwardenServer">
-                  {{ t('LabelContinue') }}
-                </v-btn>
-              </div>
-            </template>
-
-            <template v-else-if="adapter === 'karakeep'">
-              <div class="headline">
-                {{ t('LabelServersetup') }}
-              </div>
-              <v-text-field
-                v-model="server"
-                :rules="[validateUrl]"
-                :label="t('LabelKarakeepurl')"
-                :loading="isServerTestRunning"
-                :error-messages="serverTestError || serverisNotHttps" />
-              <v-text-field
-                v-model="password"
-                :label="t('LabelApiKey')"
-                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-                :type="showPassword ? 'text' : 'password'"
-                @click:append="showPassword = !showPassword" />
-
-              <div class="d-flex flex-row justify-space-between pb-2">
-                <v-btn @click="currentStep--">
-                  {{ t('LabelBack') }}
-                </v-btn>
-                <v-btn
-                  class="primary"
-                  @click="testKarakeepServer">
-                  {{ t('LabelContinue') }}
-                </v-btn>
-              </div>
-            </template>
-
-            <template v-else-if="adapter === 'webdav'">
-              <div class="headline">
-                {{ t('LabelServersetup') }}
-              </div>
-              <v-text-field
-                v-model="server"
-                :rules="[validateUrl]"
-                :label="t('LabelWebdavurl')"
-                :loading="isServerTestRunning"
-                :error-messages="serverTestError || serverisNotHttps" />
-              <v-text-field
-                v-model="username"
-                :label="t('LabelUsername')" />
-              <v-text-field
-                v-model="password"
-                :label="t('LabelPassword')"
-                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-                :type="showPassword ? 'text' : 'password'"
-                @click:append="showPassword = !showPassword" />
-              <v-text-field
-                v-model="passphrase"
-                class="mt-2"
-                :label="t('LabelPassphrase')"
-                :hint="t('DescriptionPassphrase')"
-                :persistent-hint="true"
-                :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
-                :type="showPassphrase ? 'text' : 'password'"
-                @click:append="showPassphrase = !showPassphrase" />
-              <div class="d-flex flex-row justify-space-between pb-2">
-                <v-btn @click="currentStep--">
-                  {{ t('LabelBack') }}
-                </v-btn>
-                <v-btn
-                  class="primary"
-                  @click="testWebdavServer">
-                  {{ t('LabelContinue') }}
-                </v-btn>
-              </div>
-            </template>
-
-            <template v-else-if="adapter === 'git'">
-              <div class="headline">
-                {{ t('LabelServersetup') }}
-              </div>
-              <v-text-field
-                v-model="server"
-                :rules="[validateUrl]"
-                :label="t('LabelGiturl')" />
-              <v-text-field
-                v-model="username"
-                :label="t('LabelUsername')" />
-              <v-text-field
-                v-model="password"
-                :label="t('LabelPassword')"
-                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-                :type="showPassword ? 'text' : 'password'"
-                @click:append="showPassword = !showPassword" />
-              <div class="d-flex flex-row justify-space-between pb-2">
-                <v-btn @click="currentStep--">
-                  {{ t('LabelBack') }}
-                </v-btn>
-                <v-btn
-                  class="primary"
-                  @click="currentStep++">
-                  {{ t('LabelContinue') }}
-                </v-btn>
-              </div>
-            </template>
-
-            <template v-else-if="adapter === 'google-drive'">
-              <div class="headline">
-                {{ t('LabelGoogledrivesetup') }}
-              </div>
-              <v-btn
-                color="primary"
-                @click="loginGoogleDrive">
-                {{ t('LabelLogingoogle') }}
-              </v-btn>
-              <p class="mt-1">
-                {{ t('DescriptionLogingoogle') }}
-              </p>
-              <div class="d-flex flex-row justify-space-between pb-2">
-                <v-btn @click="currentStep--">
-                  {{ t('LabelBack') }}
-                </v-btn>
-              </div>
-            </template>
-          </v-stepper-content>
-
-          <v-stepper-content step="3">
-            <div class="headline">
-              {{ t('LabelSyncfoldersetup') }}
-            </div>
-
-            <template v-if="adapter === 'nextcloud-bookmarks'">
-              <div class="text-h6">
-                {{ t('LabelServerfolder') }}
-              </div>
-              <div class="caption">
-                {{ t('DescriptionServerfolder') }}
-              </div>
-              <v-text-field
-                v-model="serverRoot"
-                :placeholder="'/'"
-                :rules="[validateServerRoot]"
-                :label="t('LabelServerfolder')" />
-            </template>
-
-            <template v-if="adapter === 'linkwarden'">
-              <div class="text-h6">
-                {{ t('LabelServerfolder') }}
-              </div>
-              <div class="caption">
-                {{ t('DescriptionServerfolderlinkwarden') }}
-              </div>
-              <v-text-field
-                v-model="serverFolder"
-                :label="t('LabelServerfolder')" />
-            </template>
-
-            <template v-if="adapter === 'karakeep'">
-              <div class="text-h6">
-                {{ t('LabelServerfolder') }}
-              </div>
-              <div class="caption">
-                {{ t('DescriptionServerfolderkarakeep') }}
-              </div>
-              <v-text-field
-                v-model="serverFolder"
-                :label="t('LabelServerfolder')" />
-            </template>
-
-            <template v-if="adapter === 'webdav'">
-              <div class="text-h6">
-                {{ t('LabelBookmarksfile') }}
-              </div>
-              <v-text-field
-                v-model="bookmark_file"
-                class="mb-2"
-                append-icon="mdi-file-document"
-                :rules="[validateBookmarksFile]"
-                :label="t('LabelBookmarksfile')"
-                :hint="t('DescriptionBookmarksfile')"
-                :persistent-hint="true" />
-              <OptionFileType
-                v-model="bookmark_file_type" />
-            </template>
-
-            <template v-if="adapter === 'git'">
-              <div class="text-h6">
-                {{ t('LabelBookmarksfile') }}
-              </div>
-              <v-text-field
-                v-model="bookmark_file"
-                class="mb-2"
-                append-icon="mdi-file-document"
-                :rules="[validateBookmarksFile]"
-                :label="t('LabelBookmarksfile')"
-                :hint="t('DescriptionBookmarksfilegit')"
-                :persistent-hint="true" />
-              <OptionFileType
-                v-model="bookmark_file_type" />
-              <v-text-field
-                v-model="branch"
-                class="mb-2"
-                :label="t('LabelGitbranch')" />
-            </template>
-
-            <template v-if="adapter === 'google-drive'">
-              <div class="text-h6">
-                {{ t('LabelBookmarksfile') }}
-              </div>
-              <v-text-field
-                v-model="bookmark_file"
-                append-icon="mdi-file-document"
-                :rules="[validateBookmarksFileGoogle]"
-                :label="t('LabelBookmarksfile')"
-                :hint="t('DescriptionBookmarksfilegoogle')"
-                :persistent-hint="true" />
-              <v-text-field
-                v-model="passphrase"
-                :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
-                :type="showPassphrase ? 'text' : 'password'"
-                class="mt-2"
-                :label="t('LabelPassphrase')"
-                :hint="t('DescriptionPassphrase')"
-                :persistent-hint="true"
-                @click:append="showPassphrase = !showPassphrase" />
-            </template>
-
-            <OptionSyncFolder
-              v-if="isBrowser"
-              v-model="localRoot" />
-
-            <div class="d-flex flex-row justify-space-between pb-2">
-              <v-btn @click="currentStep--">
-                {{ t('LabelBack') }}
-              </v-btn>
-              <v-btn
-                :disabled="isBrowser? !localRoot : false"
-                color="primary"
-                @click="currentStep++">
-                {{ t('LabelContinue') }}
-              </v-btn>
-            </div>
-          </v-stepper-content>
-
-          <v-stepper-content step="4">
-            <div class="headline">
-              {{ t('LabelSyncbehaviorsetup') }}
-            </div>
-            <v-switch
-              v-model="enabled"
-              :aria-label="t('LabelAutosync')"
-              :label="t('LabelAutosync')"
-              dense
-              class="mt-0 pt-0" />
-            <OptionSyncInterval
-              v-if="enabled"
-              v-model="syncInterval" />
-            <OptionSyncStrategy
-              v-model="strategy" />
-            <OptionNestedSync
-              v-if="isBrowser"
-              v-model="nestedSync" />
-            <v-switch
-              v-if="adapter === 'nextcloud-bookmarks'"
-              v-model="clickCountEnabled"
-              :aria-label="t('LabelClickcount')"
-              :label="t('LabelClickcount')"
-              :hint="t('DescriptionClickcount')"
+        <v-stepper-content step="1">
+          <div class="headline">
+            {{ t('LabelAccountlabel') }}
+          </div>
+          <v-form>
+            <v-text-field
+              v-model="label"
+              append-icon="mdi-label"
+              class="mt-2 mb-4"
+              :label="t('LabelAccountlabel')"
+              :hint="t('DescriptionAccountlabel')"
               :persistent-hint="true"
-              dense
-              class="mt-0 pt-0 mb-4" />
+              @keydown.enter.prevent="currentStep++" />
+          </v-form>
+          <div class="d-flex flex-row justify-space-between pb-2">
+            <v-btn @click="currentStep--">
+              {{ t('LabelBack') }}
+            </v-btn>
+            <v-btn
+              class="primary"
+              @click="currentStep++">
+              {{ t('LabelContinue') }}
+            </v-btn>
+          </div>
+        </v-stepper-content>
+
+        <v-stepper-content step="2">
+          <template v-if="adapter === 'nextcloud-bookmarks'">
+            <div class="headline">
+              {{ t('LabelServersetup') }}
+            </div>
+            <v-text-field
+              v-model="server"
+              :rules="[validateUrl]"
+              :label="t('LabelNextcloudurl')"
+              :loading="isServerTestRunning || isLoginFlowRunning"
+              :error-messages="serverisNotHttps || serverTestError || loginFlowError"
+              @keydown.enter="testNextcloudServer">
+              <template
+                slot="append-outer">
+                <v-icon
+                  v-if="serverTestSuccessful"
+                  color="green"
+                  title="Server connection successful">
+                  mdi-check
+                </v-icon>
+              </template>
+            </v-text-field>
+            <div class="d-flex flex-row justify-space-between pb-2">
+              <v-btn @click="currentStep--">
+                {{ t('LabelBack') }}
+              </v-btn>
+              <v-btn
+                v-if="!serverTestSuccessful"
+                class="primary"
+                @click="testNextcloudServer">
+                {{ t('LabelConnect') }}
+              </v-btn>
+              <template v-if="serverTestSuccessful">
+                <v-btn
+                  v-if="!isLoginFlowRunning"
+                  class="primary"
+                  @click="onFlowStart">
+                  {{ t('LabelLoginFlowStart') }}
+                </v-btn>
+                <v-btn
+                  v-if="isLoginFlowRunning"
+                  @click="onFlowStop">
+                  {{ t('LabelLoginFlowStop') }}
+                </v-btn>
+              </template>
+            </div>
+          </template>
+
+          <template v-else-if="adapter === 'linkwarden'">
+            <div class="headline">
+              {{ t('LabelServersetup') }}
+            </div>
+            <v-text-field
+              v-model="server"
+              :rules="[validateUrl]"
+              :label="t('LabelLinkwardenurl')"
+              :loading="isServerTestRunning"
+              :error-messages="serverTestError || serverisNotHttps" />
+            <v-text-field
+              v-model="username"
+              :label="t('LabelUsername')" />
+            <v-text-field
+              v-model="password"
+              :label="t('LabelAccesstoken')"
+              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              :type="showPassword ? 'text' : 'password'"
+              @click:append="showPassword = !showPassword" />
 
             <div class="d-flex flex-row justify-space-between pb-2">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
               <v-btn
-                color="primary"
-                @click="onCreate()">
+                class="primary"
+                @click="testLinkwardenServer">
                 {{ t('LabelContinue') }}
               </v-btn>
             </div>
-          </v-stepper-content>
+          </template>
 
-          <v-stepper-content step="5">
+          <template v-else-if="adapter === 'karakeep'">
             <div class="headline">
-              {{ t('LabelAccountcreated') }} <v-icon>mdi-check</v-icon>
+              {{ t('LabelServersetup') }}
             </div>
-            <div v-if="isBrowser">
-              {{ t('DescriptionAccountcreated') }}
+            <v-text-field
+              v-model="server"
+              :rules="[validateUrl]"
+              :label="t('LabelKarakeepurl')"
+              :loading="isServerTestRunning"
+              :error-messages="serverTestError || serverisNotHttps" />
+            <v-text-field
+              v-model="password"
+              :label="t('LabelApiKey')"
+              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              :type="showPassword ? 'text' : 'password'"
+              @click:append="showPassword = !showPassword" />
+
+            <div class="d-flex flex-row justify-space-between pb-2">
+              <v-btn @click="currentStep--">
+                {{ t('LabelBack') }}
+              </v-btn>
+              <v-btn
+                class="primary"
+                @click="testKarakeepServer">
+                {{ t('LabelContinue') }}
+              </v-btn>
             </div>
-          </v-stepper-content>
-        </v-stepper-items>
-      </v-stepper>
-    </v-card>
+          </template>
+
+          <template v-else-if="adapter === 'webdav'">
+            <div class="headline">
+              {{ t('LabelServersetup') }}
+            </div>
+            <v-text-field
+              v-model="server"
+              :rules="[validateUrl]"
+              :label="t('LabelWebdavurl')"
+              :loading="isServerTestRunning"
+              :error-messages="serverTestError || serverisNotHttps" />
+            <v-text-field
+              v-model="username"
+              :label="t('LabelUsername')" />
+            <v-text-field
+              v-model="password"
+              :label="t('LabelPassword')"
+              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              :type="showPassword ? 'text' : 'password'"
+              @click:append="showPassword = !showPassword" />
+            <v-text-field
+              v-model="passphrase"
+              class="mt-2"
+              :label="t('LabelPassphrase')"
+              :hint="t('DescriptionPassphrase')"
+              :persistent-hint="true"
+              :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
+              :type="showPassphrase ? 'text' : 'password'"
+              @click:append="showPassphrase = !showPassphrase" />
+            <div class="d-flex flex-row justify-space-between pb-2">
+              <v-btn @click="currentStep--">
+                {{ t('LabelBack') }}
+              </v-btn>
+              <v-btn
+                class="primary"
+                @click="testWebdavServer">
+                {{ t('LabelContinue') }}
+              </v-btn>
+            </div>
+          </template>
+
+          <template v-else-if="adapter === 'git'">
+            <div class="headline">
+              {{ t('LabelServersetup') }}
+            </div>
+            <v-text-field
+              v-model="server"
+              :rules="[validateUrl]"
+              :label="t('LabelGiturl')" />
+            <v-text-field
+              v-model="username"
+              :label="t('LabelUsername')" />
+            <v-text-field
+              v-model="password"
+              :label="t('LabelPassword')"
+              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              :type="showPassword ? 'text' : 'password'"
+              @click:append="showPassword = !showPassword" />
+            <div class="d-flex flex-row justify-space-between pb-2">
+              <v-btn @click="currentStep--">
+                {{ t('LabelBack') }}
+              </v-btn>
+              <v-btn
+                class="primary"
+                @click="currentStep++">
+                {{ t('LabelContinue') }}
+              </v-btn>
+            </div>
+          </template>
+
+          <template v-else-if="adapter === 'google-drive'">
+            <div class="headline">
+              {{ t('LabelGoogledrivesetup') }}
+            </div>
+            <v-btn
+              color="primary"
+              @click="loginGoogleDrive">
+              {{ t('LabelLogingoogle') }}
+            </v-btn>
+            <p class="mt-1">
+              {{ t('DescriptionLogingoogle') }}
+            </p>
+            <div class="d-flex flex-row justify-space-between pb-2">
+              <v-btn @click="currentStep--">
+                {{ t('LabelBack') }}
+              </v-btn>
+            </div>
+          </template>
+        </v-stepper-content>
+
+        <v-stepper-content step="3">
+          <div class="headline">
+            {{ t('LabelSyncfoldersetup') }}
+          </div>
+
+          <template v-if="adapter === 'nextcloud-bookmarks'">
+            <div class="text-h6">
+              {{ t('LabelServerfolder') }}
+            </div>
+            <div class="caption">
+              {{ t('DescriptionServerfolder') }}
+            </div>
+            <v-text-field
+              v-model="serverRoot"
+              :placeholder="'/'"
+              :rules="[validateServerRoot]"
+              :label="t('LabelServerfolder')" />
+          </template>
+
+          <template v-if="adapter === 'linkwarden'">
+            <div class="text-h6">
+              {{ t('LabelServerfolder') }}
+            </div>
+            <div class="caption">
+              {{ t('DescriptionServerfolderlinkwarden') }}
+            </div>
+            <v-text-field
+              v-model="serverFolder"
+              :label="t('LabelServerfolder')" />
+          </template>
+
+          <template v-if="adapter === 'karakeep'">
+            <div class="text-h6">
+              {{ t('LabelServerfolder') }}
+            </div>
+            <div class="caption">
+              {{ t('DescriptionServerfolderkarakeep') }}
+            </div>
+            <v-text-field
+              v-model="serverFolder"
+              :label="t('LabelServerfolder')" />
+          </template>
+
+          <template v-if="adapter === 'webdav'">
+            <div class="text-h6">
+              {{ t('LabelBookmarksfile') }}
+            </div>
+            <v-text-field
+              v-model="bookmark_file"
+              class="mb-2"
+              append-icon="mdi-file-document"
+              :rules="[validateBookmarksFile]"
+              :label="t('LabelBookmarksfile')"
+              :hint="t('DescriptionBookmarksfile')"
+              :persistent-hint="true" />
+            <OptionFileType
+              v-model="bookmark_file_type" />
+          </template>
+
+          <template v-if="adapter === 'git'">
+            <div class="text-h6">
+              {{ t('LabelBookmarksfile') }}
+            </div>
+            <v-text-field
+              v-model="bookmark_file"
+              class="mb-2"
+              append-icon="mdi-file-document"
+              :rules="[validateBookmarksFile]"
+              :label="t('LabelBookmarksfile')"
+              :hint="t('DescriptionBookmarksfilegit')"
+              :persistent-hint="true" />
+            <OptionFileType
+              v-model="bookmark_file_type" />
+            <v-text-field
+              v-model="branch"
+              class="mb-2"
+              :label="t('LabelGitbranch')" />
+          </template>
+
+          <template v-if="adapter === 'google-drive'">
+            <div class="text-h6">
+              {{ t('LabelBookmarksfile') }}
+            </div>
+            <v-text-field
+              v-model="bookmark_file"
+              append-icon="mdi-file-document"
+              :rules="[validateBookmarksFileGoogle]"
+              :label="t('LabelBookmarksfile')"
+              :hint="t('DescriptionBookmarksfilegoogle')"
+              :persistent-hint="true" />
+            <v-text-field
+              v-model="passphrase"
+              :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
+              :type="showPassphrase ? 'text' : 'password'"
+              class="mt-2"
+              :label="t('LabelPassphrase')"
+              :hint="t('DescriptionPassphrase')"
+              :persistent-hint="true"
+              @click:append="showPassphrase = !showPassphrase" />
+          </template>
+
+          <OptionSyncFolder
+            v-if="isBrowser"
+            v-model="localRoot" />
+
+          <div class="d-flex flex-row justify-space-between pb-2">
+            <v-btn @click="currentStep--">
+              {{ t('LabelBack') }}
+            </v-btn>
+            <v-btn
+              :disabled="isBrowser? !localRoot : false"
+              color="primary"
+              @click="currentStep++">
+              {{ t('LabelContinue') }}
+            </v-btn>
+          </div>
+        </v-stepper-content>
+
+        <v-stepper-content step="4">
+          <div class="headline">
+            {{ t('LabelSyncbehaviorsetup') }}
+          </div>
+          <v-switch
+            v-model="enabled"
+            :aria-label="t('LabelAutosync')"
+            :label="t('LabelAutosync')"
+            dense
+            class="mt-0 pt-0" />
+          <OptionSyncInterval
+            v-if="enabled"
+            v-model="syncInterval" />
+          <OptionSyncStrategy
+            v-model="strategy" />
+          <OptionNestedSync
+            v-if="isBrowser"
+            v-model="nestedSync" />
+          <v-switch
+            v-if="adapter === 'nextcloud-bookmarks'"
+            v-model="clickCountEnabled"
+            :aria-label="t('LabelClickcount')"
+            :label="t('LabelClickcount')"
+            :hint="t('DescriptionClickcount')"
+            :persistent-hint="true"
+            dense
+            class="mt-0 pt-0 mb-4" />
+
+          <div class="d-flex flex-row justify-space-between pb-2">
+            <v-btn @click="currentStep--">
+              {{ t('LabelBack') }}
+            </v-btn>
+            <v-btn
+              color="primary"
+              @click="onCreate()">
+              {{ t('LabelContinue') }}
+            </v-btn>
+          </div>
+        </v-stepper-content>
+
+        <v-stepper-content step="5">
+          <div class="headline">
+            {{ t('LabelAccountcreated') }} <v-icon>mdi-check</v-icon>
+          </div>
+          <div v-if="isBrowser">
+            {{ t('DescriptionAccountcreated') }}
+          </div>
+        </v-stepper-content>
+      </v-stepper-items>
+    </v-stepper>
   </v-container>
 </template>
 

--- a/src/ui/views/NewAccount.vue
+++ b/src/ui/views/NewAccount.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <v-stepper v-model="currentStep" class="mt-3 mb-9">
+    <v-stepper v-model="currentStep" class="options mt-3 mb-9">
       <v-stepper-header>
         <v-stepper-step
           :complete="currentStep > 0"
@@ -48,7 +48,7 @@
               </div>
             </v-radio-group>
           </v-form>
-          <div class="d-flex flex-row-reverse pb-2">
+          <div class="form-buttons flex-row-reverse justify-start">
             <v-btn
               class="primary"
               @click="currentStep++">
@@ -79,7 +79,7 @@
               :persistent-hint="true"
               @keydown.enter.prevent="currentStep++" />
           </v-form>
-          <div class="d-flex flex-row justify-space-between pb-2">
+          <div class="form-buttons">
             <v-btn @click="currentStep--">
               {{ t('LabelBack') }}
             </v-btn>
@@ -96,24 +96,26 @@
             <div class="headline">
               {{ t('LabelServersetup') }}
             </div>
-            <v-text-field
-              v-model="server"
-              :rules="[validateUrl]"
-              :label="t('LabelNextcloudurl')"
-              :loading="isServerTestRunning || isLoginFlowRunning"
-              :error-messages="serverisNotHttps || serverTestError || loginFlowError"
-              @keydown.enter="testNextcloudServer">
-              <template
-                slot="append-outer">
-                <v-icon
-                  v-if="serverTestSuccessful"
-                  color="green"
-                  title="Server connection successful">
-                  mdi-check
-                </v-icon>
-              </template>
-            </v-text-field>
-            <div class="d-flex flex-row justify-space-between pb-2">
+            <v-form>
+              <v-text-field
+                v-model="server"
+                :rules="[validateUrl]"
+                :label="t('LabelNextcloudurl')"
+                :loading="isServerTestRunning || isLoginFlowRunning"
+                :error-messages="serverisNotHttps || serverTestError || loginFlowError"
+                @keydown.enter="testNextcloudServer">
+                <template
+                  slot="append-outer">
+                  <v-icon
+                    v-if="serverTestSuccessful"
+                    color="green"
+                    title="Server connection successful">
+                    mdi-check
+                  </v-icon>
+                </template>
+              </v-text-field>
+            </v-form>
+            <div class="form-buttons">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -143,23 +145,24 @@
             <div class="headline">
               {{ t('LabelServersetup') }}
             </div>
-            <v-text-field
-              v-model="server"
-              :rules="[validateUrl]"
-              :label="t('LabelLinkwardenurl')"
-              :loading="isServerTestRunning"
-              :error-messages="serverTestError || serverisNotHttps" />
-            <v-text-field
-              v-model="username"
-              :label="t('LabelUsername')" />
-            <v-text-field
-              v-model="password"
-              :label="t('LabelAccesstoken')"
-              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              :type="showPassword ? 'text' : 'password'"
-              @click:append="showPassword = !showPassword" />
-
-            <div class="d-flex flex-row justify-space-between pb-2">
+             <v-form>
+              <v-text-field
+                v-model="server"
+                :rules="[validateUrl]"
+                :label="t('LabelLinkwardenurl')"
+                :loading="isServerTestRunning"
+                :error-messages="serverTestError || serverisNotHttps" />
+              <v-text-field
+                v-model="username"
+                :label="t('LabelUsername')" />
+              <v-text-field
+                v-model="password"
+                :label="t('LabelAccesstoken')"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassword ? 'text' : 'password'"
+                @click:append="showPassword = !showPassword" />
+            </v-form>
+            <div class="form-buttons">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -175,20 +178,21 @@
             <div class="headline">
               {{ t('LabelServersetup') }}
             </div>
-            <v-text-field
-              v-model="server"
-              :rules="[validateUrl]"
-              :label="t('LabelKarakeepurl')"
-              :loading="isServerTestRunning"
-              :error-messages="serverTestError || serverisNotHttps" />
-            <v-text-field
-              v-model="password"
-              :label="t('LabelApiKey')"
-              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              :type="showPassword ? 'text' : 'password'"
-              @click:append="showPassword = !showPassword" />
-
-            <div class="d-flex flex-row justify-space-between pb-2">
+            <v-form>
+              <v-text-field
+                v-model="server"
+                :rules="[validateUrl]"
+                :label="t('LabelKarakeepurl')"
+                :loading="isServerTestRunning"
+                :error-messages="serverTestError || serverisNotHttps" />
+              <v-text-field
+                v-model="password"
+                :label="t('LabelApiKey')"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassword ? 'text' : 'password'"
+                @click:append="showPassword = !showPassword" />
+            </v-form>
+            <div class="form-buttons">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -204,31 +208,33 @@
             <div class="headline">
               {{ t('LabelServersetup') }}
             </div>
-            <v-text-field
-              v-model="server"
-              :rules="[validateUrl]"
-              :label="t('LabelWebdavurl')"
-              :loading="isServerTestRunning"
-              :error-messages="serverTestError || serverisNotHttps" />
-            <v-text-field
-              v-model="username"
-              :label="t('LabelUsername')" />
-            <v-text-field
-              v-model="password"
-              :label="t('LabelPassword')"
-              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              :type="showPassword ? 'text' : 'password'"
-              @click:append="showPassword = !showPassword" />
-            <v-text-field
-              v-model="passphrase"
-              class="mt-2"
-              :label="t('LabelPassphrase')"
-              :hint="t('DescriptionPassphrase')"
-              :persistent-hint="true"
-              :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
-              :type="showPassphrase ? 'text' : 'password'"
-              @click:append="showPassphrase = !showPassphrase" />
-            <div class="d-flex flex-row justify-space-between pb-2">
+            <v-form>
+              <v-text-field
+                v-model="server"
+                :rules="[validateUrl]"
+                :label="t('LabelWebdavurl')"
+                :loading="isServerTestRunning"
+                :error-messages="serverTestError || serverisNotHttps" />
+              <v-text-field
+                v-model="username"
+                :label="t('LabelUsername')" />
+              <v-text-field
+                v-model="password"
+                :label="t('LabelPassword')"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassword ? 'text' : 'password'"
+                @click:append="showPassword = !showPassword" />
+              <v-text-field
+                v-model="passphrase"
+                class="mt-2"
+                :label="t('LabelPassphrase')"
+                :hint="t('DescriptionPassphrase')"
+                :persistent-hint="true"
+                :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassphrase ? 'text' : 'password'"
+                @click:append="showPassphrase = !showPassphrase" />
+            </v-form>
+            <div class="form-buttons">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -244,20 +250,22 @@
             <div class="headline">
               {{ t('LabelServersetup') }}
             </div>
-            <v-text-field
-              v-model="server"
-              :rules="[validateUrl]"
-              :label="t('LabelGiturl')" />
-            <v-text-field
-              v-model="username"
-              :label="t('LabelUsername')" />
-            <v-text-field
-              v-model="password"
-              :label="t('LabelPassword')"
-              :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              :type="showPassword ? 'text' : 'password'"
-              @click:append="showPassword = !showPassword" />
-            <div class="d-flex flex-row justify-space-between pb-2">
+            <v-form>
+              <v-text-field
+                v-model="server"
+                :rules="[validateUrl]"
+                :label="t('LabelGiturl')" />
+              <v-text-field
+                v-model="username"
+                :label="t('LabelUsername')" />
+              <v-text-field
+                v-model="password"
+                :label="t('LabelPassword')"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassword ? 'text' : 'password'"
+                @click:append="showPassword = !showPassword" />
+            </v-form>
+            <div class="form-buttons">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -273,15 +281,17 @@
             <div class="headline">
               {{ t('LabelGoogledrivesetup') }}
             </div>
-            <v-btn
-              color="primary"
-              @click="loginGoogleDrive">
-              {{ t('LabelLogingoogle') }}
-            </v-btn>
-            <p class="mt-1">
-              {{ t('DescriptionLogingoogle') }}
-            </p>
-            <div class="d-flex flex-row justify-space-between pb-2">
+            <v-form class="mt-2">
+              <v-btn
+                color="primary"
+                @click="loginGoogleDrive">
+                {{ t('LabelLogingoogle') }}
+              </v-btn>
+              <p class="mt-2">
+                {{ t('DescriptionLogingoogle') }}
+              </p>
+            </v-form>
+            <div class="form-buttons">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -293,108 +303,108 @@
           <div class="headline">
             {{ t('LabelSyncfoldersetup') }}
           </div>
+          <v-form>
+            <template v-if="adapter === 'nextcloud-bookmarks'">
+              <div class="text-h6">
+                {{ t('LabelServerfolder') }}
+              </div>
+              <div class="caption">
+                {{ t('DescriptionServerfolder') }}
+              </div>
+              <v-text-field
+                v-model="serverRoot"
+                :placeholder="'/'"
+                :rules="[validateServerRoot]"
+                :label="t('LabelServerfolder')" />
+            </template>
 
-          <template v-if="adapter === 'nextcloud-bookmarks'">
-            <div class="text-h6">
-              {{ t('LabelServerfolder') }}
-            </div>
-            <div class="caption">
-              {{ t('DescriptionServerfolder') }}
-            </div>
-            <v-text-field
-              v-model="serverRoot"
-              :placeholder="'/'"
-              :rules="[validateServerRoot]"
-              :label="t('LabelServerfolder')" />
-          </template>
+            <template v-if="adapter === 'linkwarden'">
+              <div class="text-h6">
+                {{ t('LabelServerfolder') }}
+              </div>
+              <div class="caption">
+                {{ t('DescriptionServerfolderlinkwarden') }}
+              </div>
+              <v-text-field
+                v-model="serverFolder"
+                :label="t('LabelServerfolder')" />
+            </template>
 
-          <template v-if="adapter === 'linkwarden'">
-            <div class="text-h6">
-              {{ t('LabelServerfolder') }}
-            </div>
-            <div class="caption">
-              {{ t('DescriptionServerfolderlinkwarden') }}
-            </div>
-            <v-text-field
-              v-model="serverFolder"
-              :label="t('LabelServerfolder')" />
-          </template>
+            <template v-if="adapter === 'karakeep'">
+              <div class="text-h6">
+                {{ t('LabelServerfolder') }}
+              </div>
+              <div class="caption">
+                {{ t('DescriptionServerfolderkarakeep') }}
+              </div>
+              <v-text-field
+                v-model="serverFolder"
+                :label="t('LabelServerfolder')" />
+            </template>
 
-          <template v-if="adapter === 'karakeep'">
-            <div class="text-h6">
-              {{ t('LabelServerfolder') }}
-            </div>
-            <div class="caption">
-              {{ t('DescriptionServerfolderkarakeep') }}
-            </div>
-            <v-text-field
-              v-model="serverFolder"
-              :label="t('LabelServerfolder')" />
-          </template>
+            <template v-if="adapter === 'webdav'">
+              <div class="text-h6">
+                {{ t('LabelBookmarksfile') }}
+              </div>
+              <v-text-field
+                v-model="bookmark_file"
+                class="mb-2"
+                append-icon="mdi-file-document"
+                :rules="[validateBookmarksFile]"
+                :label="t('LabelBookmarksfile')"
+                :hint="t('DescriptionBookmarksfile')"
+                :persistent-hint="true" />
+              <OptionFileType
+                v-model="bookmark_file_type" />
+            </template>
 
-          <template v-if="adapter === 'webdav'">
-            <div class="text-h6">
-              {{ t('LabelBookmarksfile') }}
-            </div>
-            <v-text-field
-              v-model="bookmark_file"
-              class="mb-2"
-              append-icon="mdi-file-document"
-              :rules="[validateBookmarksFile]"
-              :label="t('LabelBookmarksfile')"
-              :hint="t('DescriptionBookmarksfile')"
-              :persistent-hint="true" />
-            <OptionFileType
-              v-model="bookmark_file_type" />
-          </template>
+            <template v-if="adapter === 'git'">
+              <div class="text-h6">
+                {{ t('LabelBookmarksfile') }}
+              </div>
+              <v-text-field
+                v-model="bookmark_file"
+                class="mb-2"
+                append-icon="mdi-file-document"
+                :rules="[validateBookmarksFile]"
+                :label="t('LabelBookmarksfile')"
+                :hint="t('DescriptionBookmarksfilegit')"
+                :persistent-hint="true" />
+              <OptionFileType
+                v-model="bookmark_file_type" />
+              <v-text-field
+                v-model="branch"
+                class="mb-2"
+                :label="t('LabelGitbranch')" />
+            </template>
 
-          <template v-if="adapter === 'git'">
-            <div class="text-h6">
-              {{ t('LabelBookmarksfile') }}
-            </div>
-            <v-text-field
-              v-model="bookmark_file"
-              class="mb-2"
-              append-icon="mdi-file-document"
-              :rules="[validateBookmarksFile]"
-              :label="t('LabelBookmarksfile')"
-              :hint="t('DescriptionBookmarksfilegit')"
-              :persistent-hint="true" />
-            <OptionFileType
-              v-model="bookmark_file_type" />
-            <v-text-field
-              v-model="branch"
-              class="mb-2"
-              :label="t('LabelGitbranch')" />
-          </template>
+            <template v-if="adapter === 'google-drive'">
+              <div class="text-h6">
+                {{ t('LabelBookmarksfile') }}
+              </div>
+              <v-text-field
+                v-model="bookmark_file"
+                append-icon="mdi-file-document"
+                :rules="[validateBookmarksFileGoogle]"
+                :label="t('LabelBookmarksfile')"
+                :hint="t('DescriptionBookmarksfilegoogle')"
+                :persistent-hint="true" />
+              <v-text-field
+                v-model="passphrase"
+                :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showPassphrase ? 'text' : 'password'"
+                class="mt-2"
+                :label="t('LabelPassphrase')"
+                :hint="t('DescriptionPassphrase')"
+                :persistent-hint="true"
+                @click:append="showPassphrase = !showPassphrase" />
+            </template>
+            <OptionSyncFolder
+              v-if="isBrowser"
+              v-model="localRoot" />
+          </v-form>
 
-          <template v-if="adapter === 'google-drive'">
-            <div class="text-h6">
-              {{ t('LabelBookmarksfile') }}
-            </div>
-            <v-text-field
-              v-model="bookmark_file"
-              append-icon="mdi-file-document"
-              :rules="[validateBookmarksFileGoogle]"
-              :label="t('LabelBookmarksfile')"
-              :hint="t('DescriptionBookmarksfilegoogle')"
-              :persistent-hint="true" />
-            <v-text-field
-              v-model="passphrase"
-              :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
-              :type="showPassphrase ? 'text' : 'password'"
-              class="mt-2"
-              :label="t('LabelPassphrase')"
-              :hint="t('DescriptionPassphrase')"
-              :persistent-hint="true"
-              @click:append="showPassphrase = !showPassphrase" />
-          </template>
-
-          <OptionSyncFolder
-            v-if="isBrowser"
-            v-model="localRoot" />
-
-          <div class="d-flex flex-row justify-space-between pb-2">
+          <div class="form-buttons pt-4">
             <v-btn @click="currentStep--">
               {{ t('LabelBack') }}
             </v-btn>
@@ -411,31 +421,32 @@
           <div class="headline">
             {{ t('LabelSyncbehaviorsetup') }}
           </div>
-          <v-switch
-            v-model="enabled"
-            :aria-label="t('LabelAutosync')"
-            :label="t('LabelAutosync')"
-            dense
-            class="mt-0 pt-0" />
-          <OptionSyncInterval
-            v-if="enabled"
-            v-model="syncInterval" />
-          <OptionSyncStrategy
-            v-model="strategy" />
-          <OptionNestedSync
-            v-if="isBrowser"
-            v-model="nestedSync" />
-          <v-switch
-            v-if="adapter === 'nextcloud-bookmarks'"
-            v-model="clickCountEnabled"
-            :aria-label="t('LabelClickcount')"
-            :label="t('LabelClickcount')"
-            :hint="t('DescriptionClickcount')"
-            :persistent-hint="true"
-            dense
-            class="mt-0 pt-0 mb-4" />
-
-          <div class="d-flex flex-row justify-space-between pb-2">
+          <v-form>
+            <v-switch
+              v-model="enabled"
+              :aria-label="t('LabelAutosync')"
+              :label="t('LabelAutosync')"
+              dense
+              class="mt-1 pt-1" />
+            <OptionSyncInterval
+              v-if="enabled"
+              v-model="syncInterval" />
+            <OptionSyncStrategy
+              v-model="strategy" />
+            <OptionNestedSync
+              v-if="isBrowser"
+              v-model="nestedSync" />
+            <v-switch
+              v-if="adapter === 'nextcloud-bookmarks'"
+              v-model="clickCountEnabled"
+              :aria-label="t('LabelClickcount')"
+              :label="t('LabelClickcount')"
+              :hint="t('DescriptionClickcount')"
+              :persistent-hint="true"
+              dense
+              class="mt-0 pt-0 mb-4" />
+          </v-form>
+          <div class="form-buttons">
             <v-btn @click="currentStep--">
               {{ t('LabelBack') }}
             </v-btn>
@@ -684,4 +695,27 @@ export default {
         max-width: 600px;
         margin: 0 auto;
     }
+
+    .form-buttons {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+
+    .v-stepper {
+      .v-stepper__content {
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: 0;
+        padding-right: 0;
+
+        .v-form, .headline, .form-buttons  {
+          padding-left: 24px;
+          padding-right: 24px;
+        }
+      }
+    }
+    
 </style>

--- a/src/ui/views/NewAccount.vue
+++ b/src/ui/views/NewAccount.vue
@@ -1,6 +1,8 @@
 <template>
   <v-container>
-    <v-stepper v-model="currentStep" class="options mt-3 mb-9">
+    <v-stepper
+      v-model="currentStep"
+      class="options mt-3 mb-9">
       <v-stepper-header>
         <v-stepper-step
           :complete="currentStep > 0"
@@ -145,7 +147,7 @@
             <div class="headline">
               {{ t('LabelServersetup') }}
             </div>
-             <v-form>
+            <v-form>
               <v-text-field
                 v-model="server"
                 :rules="[validateUrl]"
@@ -717,5 +719,4 @@ export default {
         }
       }
     }
-    
 </style>

--- a/src/ui/views/NewAccount.vue
+++ b/src/ui/views/NewAccount.vue
@@ -1,7 +1,6 @@
 <template>
   <v-container>
-    <v-card
-      class="options mt-3">
+    <v-card class="mt-3 mb-9">
       <v-stepper v-model="currentStep">
         <v-stepper-header>
           <v-stepper-step
@@ -50,7 +49,7 @@
                 </div>
               </v-radio-group>
             </v-form>
-            <div class="d-flex flex-row-reverse">
+            <div class="d-flex flex-row-reverse pb-2">
               <v-btn
                 class="primary"
                 @click="currentStep++">
@@ -81,7 +80,7 @@
                 :persistent-hint="true"
                 @keydown.enter.prevent="currentStep++" />
             </v-form>
-            <div class="d-flex flex-row justify-space-between">
+            <div class="d-flex flex-row justify-space-between pb-2">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -115,7 +114,7 @@
                   </v-icon>
                 </template>
               </v-text-field>
-              <div class="d-flex flex-row justify-space-between">
+              <div class="d-flex flex-row justify-space-between pb-2">
                 <v-btn @click="currentStep--">
                   {{ t('LabelBack') }}
                 </v-btn>
@@ -161,7 +160,7 @@
                 :type="showPassword ? 'text' : 'password'"
                 @click:append="showPassword = !showPassword" />
 
-              <div class="d-flex flex-row justify-space-between">
+              <div class="d-flex flex-row justify-space-between pb-2">
                 <v-btn @click="currentStep--">
                   {{ t('LabelBack') }}
                 </v-btn>
@@ -190,7 +189,7 @@
                 :type="showPassword ? 'text' : 'password'"
                 @click:append="showPassword = !showPassword" />
 
-              <div class="d-flex flex-row justify-space-between">
+              <div class="d-flex flex-row justify-space-between pb-2">
                 <v-btn @click="currentStep--">
                   {{ t('LabelBack') }}
                 </v-btn>
@@ -230,7 +229,7 @@
                 :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPassphrase ? 'text' : 'password'"
                 @click:append="showPassphrase = !showPassphrase" />
-              <div class="d-flex flex-row justify-space-between">
+              <div class="d-flex flex-row justify-space-between pb-2">
                 <v-btn @click="currentStep--">
                   {{ t('LabelBack') }}
                 </v-btn>
@@ -259,7 +258,7 @@
                 :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPassword ? 'text' : 'password'"
                 @click:append="showPassword = !showPassword" />
-              <div class="d-flex flex-row justify-space-between">
+              <div class="d-flex flex-row justify-space-between pb-2">
                 <v-btn @click="currentStep--">
                   {{ t('LabelBack') }}
                 </v-btn>
@@ -283,9 +282,11 @@
               <p class="mt-1">
                 {{ t('DescriptionLogingoogle') }}
               </p>
-              <v-btn @click="currentStep--">
-                {{ t('LabelBack') }}
-              </v-btn>
+              <div class="d-flex flex-row justify-space-between pb-2">
+                <v-btn @click="currentStep--">
+                  {{ t('LabelBack') }}
+                </v-btn>
+              </div>
             </template>
           </v-stepper-content>
 
@@ -394,7 +395,7 @@
               v-if="isBrowser"
               v-model="localRoot" />
 
-            <div class="d-flex flex-row justify-space-between">
+            <div class="d-flex flex-row justify-space-between pb-2">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -435,7 +436,7 @@
               dense
               class="mt-0 pt-0 mb-4" />
 
-            <div class="d-flex flex-row justify-space-between">
+            <div class="d-flex flex-row justify-space-between pb-2">
               <v-btn @click="currentStep--">
                 {{ t('LabelBack') }}
               </v-btn>
@@ -446,6 +447,7 @@
               </v-btn>
             </div>
           </v-stepper-content>
+
           <v-stepper-content step="5">
             <div class="headline">
               {{ t('LabelAccountcreated') }} <v-icon>mdi-check</v-icon>

--- a/src/ui/views/native/About.vue
+++ b/src/ui/views/native/About.vue
@@ -1,17 +1,14 @@
 <template>
-  <div style="position: absolute; inset: 0; overflow: hidden;">
+  <div  class="native-scroll-container">
     <Drawer :visible.sync="drawer" />
-    <v-app-bar
-      fixed
-      style="top: env(safe-area-inset-top);"
+    <v-app-bar fixed
       app>
       <v-app-bar-nav-icon
         class="mr-2 ml-n2"
         @click="drawer = !drawer" />
       <v-app-bar-title>{{ t('LabelAbout') }}</v-app-bar-title>
     </v-app-bar>
-    <v-main
-      style="height: 100%; overflow-y: auto;">
+    <v-main>
       <v-container>
         <v-card>
           <v-container class="pa-5">

--- a/src/ui/views/native/About.vue
+++ b/src/ui/views/native/About.vue
@@ -1,7 +1,8 @@
 <template>
-  <div  class="native-scroll-container">
+  <div class="native-scroll-container">
     <Drawer :visible.sync="drawer" />
-    <v-app-bar fixed
+    <v-app-bar
+      fixed
       app>
       <v-app-bar-nav-icon
         class="mr-2 ml-n2"

--- a/src/ui/views/native/About.vue
+++ b/src/ui/views/native/About.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
+  <div style="position: absolute; inset: 0; overflow: hidden;">
     <Drawer :visible.sync="drawer" />
     <v-app-bar
       fixed
@@ -11,7 +11,6 @@
       <v-app-bar-title>{{ t('LabelAbout') }}</v-app-bar-title>
     </v-app-bar>
     <v-main
-      :class="{'pt-9': true }"
       style="height: 100%; overflow-y: auto;">
       <v-container>
         <v-card>
@@ -26,7 +25,7 @@
           </v-container>
         </v-card>
         <v-card
-          class="mt-3 mb-9">
+          class="mt-3 mb-16">
           <v-container class="pa-5">
             <v-card-title>
               {{ t("LabelContributors") }}

--- a/src/ui/views/native/About.vue
+++ b/src/ui/views/native/About.vue
@@ -1,15 +1,18 @@
 <template>
-  <div>
+  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
     <Drawer :visible.sync="drawer" />
     <v-app-bar
-      absolute
+      fixed
+      style="top: env(safe-area-inset-top);"
       app>
       <v-app-bar-nav-icon
         class="mr-2 ml-n2"
         @click="drawer = !drawer" />
       <v-app-bar-title>{{ t('LabelAbout') }}</v-app-bar-title>
     </v-app-bar>
-    <v-main>
+    <v-main
+      :class="{'pt-9': true }"
+      style="height: 100%; overflow-y: auto;">
       <v-container>
         <v-card>
           <v-container class="pa-5">
@@ -23,7 +26,7 @@
           </v-container>
         </v-card>
         <v-card
-          class="mt-3">
+          class="mt-3 mb-9">
           <v-container class="pa-5">
             <v-card-title>
               {{ t("LabelContributors") }}

--- a/src/ui/views/native/AddBookmarkIntent.vue
+++ b/src/ui/views/native/AddBookmarkIntent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
+  <div style="position: absolute; inset: 0; overflow: hidden;">
     <v-app-bar
       fixed
       style="top: env(safe-area-inset-top);"
@@ -15,7 +15,6 @@
       </v-btn>
     </v-app-bar>
     <v-main
-      :class="{'pt-10': true }"
       style="height: 100%; overflow-y: auto;">
       <v-progress-circular
         v-if="loading"
@@ -24,6 +23,7 @@
         class="loading" />
       <v-card
         v-else
+        class="mt-2"
         style="min-height: 95vh">
         <v-card-text>
           <v-select

--- a/src/ui/views/native/AddBookmarkIntent.vue
+++ b/src/ui/views/native/AddBookmarkIntent.vue
@@ -1,8 +1,6 @@
 <template>
-  <div style="position: absolute; inset: 0; overflow: hidden;">
-    <v-app-bar
-      fixed
-      style="top: env(safe-area-inset-top);"
+  <div class="native-scroll-container">
+    <v-app-bar fixed
       app>
       <v-app-bar-title>Add Bookmark</v-app-bar-title>
       <v-spacer />
@@ -14,8 +12,7 @@
         Save
       </v-btn>
     </v-app-bar>
-    <v-main
-      style="height: 100%; overflow-y: auto;">
+    <v-main>
       <v-progress-circular
         v-if="loading"
         indeterminate

--- a/src/ui/views/native/AddBookmarkIntent.vue
+++ b/src/ui/views/native/AddBookmarkIntent.vue
@@ -1,7 +1,8 @@
 <template>
-  <div>
+  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
     <v-app-bar
-      absolute
+      fixed
+      style="top: env(safe-area-inset-top);"
       app>
       <v-app-bar-title>Add Bookmark</v-app-bar-title>
       <v-spacer />
@@ -13,7 +14,9 @@
         Save
       </v-btn>
     </v-app-bar>
-    <v-main>
+    <v-main
+      :class="{'pt-10': true }"
+      style="height: 100%; overflow-y: auto;">
       <v-progress-circular
         v-if="loading"
         indeterminate

--- a/src/ui/views/native/AddBookmarkIntent.vue
+++ b/src/ui/views/native/AddBookmarkIntent.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="native-scroll-container">
-    <v-app-bar fixed
+    <v-app-bar
+      fixed
       app>
       <v-app-bar-title>Add Bookmark</v-app-bar-title>
       <v-spacer />

--- a/src/ui/views/native/ImportExport.vue
+++ b/src/ui/views/native/ImportExport.vue
@@ -1,15 +1,18 @@
 <template>
-  <div>
+  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
     <Drawer :visible.sync="drawer" />
     <v-app-bar
-      absolute
+      fixed
+      style="top: env(safe-area-inset-top);"
       app>
       <v-app-bar-nav-icon
         class="mr-2 ml-n2"
         @click="drawer = !drawer" />
       <v-app-bar-title>{{ t('LabelImportExport') }}</v-app-bar-title>
     </v-app-bar>
-    <v-main>
+    <v-main
+      :class="{'pt-7': true }"
+      style="height: 100%; overflow-y: auto;">
       <ImportExportContent />
     </v-main>
   </div>

--- a/src/ui/views/native/ImportExport.vue
+++ b/src/ui/views/native/ImportExport.vue
@@ -1,17 +1,14 @@
 <template>
-  <div style="position: absolute; inset: 0; overflow: hidden;">
+  <div class="native-scroll-container">
     <Drawer :visible.sync="drawer" />
-    <v-app-bar
-      fixed
-      style="top: env(safe-area-inset-top);"
+    <v-app-bar fixed
       app>
       <v-app-bar-nav-icon
         class="mr-2 ml-n2"
         @click="drawer = !drawer" />
       <v-app-bar-title>{{ t('LabelImportExport') }}</v-app-bar-title>
     </v-app-bar>
-    <v-main
-      style="height: 100%; overflow-y: auto;">
+    <v-main>
       <ImportExportContent />
     </v-main>
   </div>

--- a/src/ui/views/native/ImportExport.vue
+++ b/src/ui/views/native/ImportExport.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
+  <div style="position: absolute; inset: 0; overflow: hidden;">
     <Drawer :visible.sync="drawer" />
     <v-app-bar
       fixed
@@ -11,7 +11,6 @@
       <v-app-bar-title>{{ t('LabelImportExport') }}</v-app-bar-title>
     </v-app-bar>
     <v-main
-      :class="{'pt-7': true }"
       style="height: 100%; overflow-y: auto;">
       <ImportExportContent />
     </v-main>

--- a/src/ui/views/native/ImportExport.vue
+++ b/src/ui/views/native/ImportExport.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="native-scroll-container">
     <Drawer :visible.sync="drawer" />
-    <v-app-bar fixed
+    <v-app-bar
+      fixed
       app>
       <v-app-bar-nav-icon
         class="mr-2 ml-n2"

--- a/src/ui/views/native/NewAccount.vue
+++ b/src/ui/views/native/NewAccount.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="native-scroll-container">
+    <v-main>
+      <NewAccountContent />
+    </v-main>
+  </div>
+</template>
+
+<script>
+import NewAccountContent from '../NewAccount'
+
+export default {
+  name: 'NewAccount',
+  components: { NewAccountContent },
+  data() {
+    return {
+      drawer: false,
+    }
+  },
+}
+</script>
+
+<style scoped></style>

--- a/src/ui/views/native/Options.vue
+++ b/src/ui/views/native/Options.vue
@@ -1,8 +1,9 @@
 <template>
-  <div>
+  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
     <v-app-bar
       app
-      absolute>
+      fixed
+      style="top: env(safe-area-inset-top);">
       <v-btn
         icon
         :to="{name: routes.TREE, params: {accountId: id}}">
@@ -18,10 +19,12 @@
         {{ t('LabelSave') }}
       </v-btn>
     </v-app-bar>
-    <v-main>
+    <v-main
+      :class="{'pt-6': true }"
+      style="height: 100%; overflow-y: auto;">
       <v-form
         v-if="!loading"
-        class="mt-3 mb-3">
+        class="mt-3 mb-9">
         <OptionsNextcloudBookmarks
           v-if="data.type === 'nextcloud-folders' || data.type === 'nextcloud-bookmarks'"
           v-bind.sync="data"

--- a/src/ui/views/native/Options.vue
+++ b/src/ui/views/native/Options.vue
@@ -1,6 +1,7 @@
 <template>
-  <div  class="native-scroll-container">
-    <v-app-bar fixed
+  <div class="native-scroll-container">
+    <v-app-bar
+      fixed
       app>
       <v-btn
         icon

--- a/src/ui/views/native/Options.vue
+++ b/src/ui/views/native/Options.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
+  <div style="position: absolute; inset: 0; overflow: hidden;">
     <v-app-bar
       app
       fixed
@@ -20,11 +20,10 @@
       </v-btn>
     </v-app-bar>
     <v-main
-      :class="{'pt-6': true }"
       style="height: 100%; overflow-y: auto;">
       <v-form
         v-if="!loading"
-        class="mt-3 mb-9">
+        class="mt-3">
         <OptionsNextcloudBookmarks
           v-if="data.type === 'nextcloud-folders' || data.type === 'nextcloud-bookmarks'"
           v-bind.sync="data"
@@ -60,6 +59,7 @@
           v-bind.sync="data"
           @reset="onReset"
           @delete="onDelete" />
+        <v-spacer style="padding-bottom: 80px;" />
       </v-form>
     </v-main>
   </div>

--- a/src/ui/views/native/Options.vue
+++ b/src/ui/views/native/Options.vue
@@ -1,9 +1,7 @@
 <template>
-  <div style="position: absolute; inset: 0; overflow: hidden;">
-    <v-app-bar
-      app
-      fixed
-      style="top: env(safe-area-inset-top);">
+  <div  class="native-scroll-container">
+    <v-app-bar fixed
+      app>
       <v-btn
         icon
         :to="{name: routes.TREE, params: {accountId: id}}">
@@ -19,11 +17,9 @@
         {{ t('LabelSave') }}
       </v-btn>
     </v-app-bar>
-    <v-main
-      style="height: 100%; overflow-y: auto;">
+    <v-main>
       <v-form
-        v-if="!loading"
-        class="mt-3">
+        v-if="!loading">
         <OptionsNextcloudBookmarks
           v-if="data.type === 'nextcloud-folders' || data.type === 'nextcloud-bookmarks'"
           v-bind.sync="data"

--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -1,9 +1,7 @@
 <template>
-  <div style="position: absolute; inset: 0; overflow: hidden;">
+  <div class="native-scroll-container">
     <Drawer :visible.sync="drawer" />
-    <v-app-bar
-      fixed
-      style="top: env(safe-area-inset-top);"
+    <v-app-bar fixed
       app>
       <v-app-bar-nav-icon
         v-if="!tree || currentFolderId === tree.id"
@@ -112,7 +110,7 @@
         <v-icon>mdi-cog</v-icon>
       </v-btn>
     </v-app-bar>
-    <v-main style="height: 100%; overflow-y: auto;">
+    <v-main>
       <v-progress-linear
         v-if="syncProgress"
         :value="syncProgress * 100 || 0"
@@ -245,7 +243,7 @@
         v-else
         flat
         tile
-        :style="{height: '100vh', width: '100vw', padding: '10vh auto'}">
+        :style="{height: '100%', width: '100vw', padding: '10vh auto', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}">
         <img
           src="icons/tree-swing.svg"
           :style="{width: '95%', maxHeight: '40vh'}">

--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -1,9 +1,9 @@
 <template>
-  <div
-    style="height:100%">
+  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
     <Drawer :visible.sync="drawer" />
     <v-app-bar
-      absolute
+      fixed
+      style="top: env(safe-area-inset-top);"
       app>
       <v-app-bar-nav-icon
         v-if="!tree || currentFolderId === tree.id"
@@ -112,7 +112,9 @@
         <v-icon>mdi-cog</v-icon>
       </v-btn>
     </v-app-bar>
-    <v-main>
+    <v-main
+      :class="{'pt-8': true }"
+      style="height: 100%; overflow-y: auto;">
       <v-progress-linear
         v-if="syncProgress"
         :value="syncProgress * 100 || 0"

--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="padding-top: env(safe-area-inset-top); position: absolute; inset: 0; overflow: hidden;">
+  <div style="position: absolute; inset: 0; overflow: hidden;">
     <Drawer :visible.sync="drawer" />
     <v-app-bar
       fixed
@@ -112,9 +112,7 @@
         <v-icon>mdi-cog</v-icon>
       </v-btn>
     </v-app-bar>
-    <v-main
-      :class="{'pt-8': true }"
-      style="height: 100%; overflow-y: auto;">
+    <v-main style="height: 100%; overflow-y: auto;">
       <v-progress-linear
         v-if="syncProgress"
         :value="syncProgress * 100 || 0"
@@ -771,5 +769,6 @@ export default {
 
 .list-full-height {
   min-height: 95vh;
+  margin-bottom: 60px;
 }
 </style>

--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="native-scroll-container">
     <Drawer :visible.sync="drawer" />
-    <v-app-bar fixed
+    <v-app-bar
+      fixed
       app>
       <v-app-bar-nav-icon
         v-if="!tree || currentFolderId === tree.id"
@@ -111,8 +112,9 @@
       </v-btn>
     </v-app-bar>
     <v-main>
-      <v-progress-linear fixed
+      <v-progress-linear
         v-if="syncProgress"
+        fixed
         :value="syncProgress * 100 || 0"
         color="blue darken-1" />
       <v-card>

--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -111,7 +111,7 @@
       </v-btn>
     </v-app-bar>
     <v-main>
-      <v-progress-linear
+      <v-progress-linear fixed
         v-if="syncProgress"
         :value="syncProgress * 100 || 0"
         color="blue darken-1" />
@@ -767,6 +767,5 @@ export default {
 
 .list-full-height {
   min-height: 95vh;
-  margin-bottom: 60px;
 }
 </style>

--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -767,5 +767,6 @@ export default {
 
 .list-full-height {
   min-height: 95vh;
+  margin-bottom: 60px;
 }
 </style>


### PR DESCRIPTION
This PR locks the position of the App Bar in the iOS and Android so that when you scroll it is still accessible. This is mostly useful when searching for bookmarks. When scrolling down the app contents will no longer scroll on top of the top status bar on iOS and Android.

Tested on iOS and Android Simulators and loading a temporary browser extension in Firefox with different screen sizes. Testing flow started with a fresh app and adding a Google Drive source and adding bookmarks. But I did fix other flows along the way if they were easily accessible.